### PR TITLE
Update the link to the slides in README to correct url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Intro to HTML/CSS
-Slides and materials are hosted at [http://girldevelopit.github.io/gdi-core-html-css/](http://girldevelopit.github.io/gdi-core-html-css/).
+Slides and materials are hosted at [http://girldevelopit.github.io/gdi-featured-html-css-intro//](http://girldevelopit.github.io/gdi-featured-html-css-intro/).
 
 ## Course description
 This is a 4-part, 8-hour course.


### PR DESCRIPTION
The link in the README was pointing to the old github.io page and was 404ing. This PR updates the link to the correct url.