### PR TITLE
Remove `title` attribute from anchor element definition slide.

### DIFF
--- a/class1.html
+++ b/class1.html
@@ -470,15 +470,14 @@ Here is a paragraph with &lt;em&gt;emphasized&lt;/em&gt; text and &lt;strong&gt;
     <!-- Links-->
     <section>
       <h3>Element: Link</h3>
-      <p>Links have three components</p>
+      <p>Links have two components</p>
       <ul>
         <li>Tag: &lt;a>&lt;/a></li>
         <li>Href attribute: "http://www.girldevelopit.com"</li>
-        <li>Title attribute: "Girl Develop It"</li>
       </ul>
-<pre><code class="html">&lt;a href="http://www.girldevelopit.com" title="Girl Develop It"&gt;Girl Develop It&lt;/a&gt;<
+<pre><code class="html">&lt;a href="http://www.girldevelopit.com"&gt;Girl Develop It&lt;/a&gt;
 </code></pre>
-      <p><a href ="http://www.girldevelopit.com" title="Girl Develop It">Girl Develop It</a></p>
+      <p><a href ="http://www.girldevelopit.com">Girl Develop It</a></p>
       <p>The &lt;a&gt; tag surrounds text or images to turn them into links</p>
     </section>
 


### PR DESCRIPTION
While `title` is a global attribute, it is rarely applied to anchor elements. The W3C [cautions specifically against this usage](https://www.w3.org/TR/WCAG20-TECHS/H33.html). See also:

- [HTML5 Accessibility Chops: title attribute use and abuse](https://www.paciellogroup.com/blog/2012/01/html5-accessibility-chops-title-attribute-use-and-abuse/)
- [How–to: Use TITLE attributes](http://a11yproject.com/posts/title-attributes/)