### PR TITLE
Added Linux support for Atom on text editor recommendations

### DIFF
--- a/class1.html
+++ b/class1.html
@@ -1,4 +1,4 @@
-<!doctype html> 
+<!doctype html>
 <html lang="en">
 
   <head>
@@ -150,7 +150,7 @@
         Chrome - Inspector<br />
         Firefox - Firebug</li>
         <li><strong>Text Editor</strong><br />
-        <a href="https://atom.io/" target="_blank">Atom</a> - Windows, Mac<br />
+        <a href="https://atom.io/" target="_blank">Atom</a> - Windows, Mac, Linux<br />
         <a href="https://notepad-plus-plus.org/" target="_blank">Notepad++</a> - Windows<br />
         <a href="http://www.sublimetext.com/" target="_blank">Sublime Text</a> - Windows, Mac, Linux<br />
         <a href="http://www.barebones.com/products/textwrangler/TextWrangler" target="_blank">TextWrangler</a> - Mac</li>


### PR DESCRIPTION
Just added Linux to the supported OS list for Atom on the text editor slide.